### PR TITLE
chore: updating interface names on dashboard

### DIFF
--- a/library/network-routers-and-switches/dashboards/network-routers-and-switches.json
+++ b/library/network-routers-and-switches/dashboards/network-routers-and-switches.json
@@ -16,7 +16,7 @@
               "height": 3,
               "width": 6
             },
-            "title": "Device Inventory [Filterable]",
+            "title": "Device Inventory",
             "rawConfiguration": {
               "dataFormatters": [
                 {
@@ -61,7 +61,7 @@
               "nrqlQueries": [
                 {
                   "accountId": 0,
-                  "query": "FROM Metric SELECT latest(ifOperStatus) AS 'Interface Status' FACET device_name, if_Alias OR if_Description AS 'interface_name' WHERE instrumentation.name = 'snmp' AND provider IN ('kentik-router','kentik-switch') LIMIT MAX"
+                  "query": "FROM Metric SELECT latest(ifOperStatus) AS 'Interface Status' FACET device_name, if_Name OR if_Alias OR if_Description AS 'interface_name' WHERE instrumentation.name = 'snmp' AND provider IN ('kentik-router','kentik-switch') LIMIT MAX"
                 }
               ]
             },
@@ -92,7 +92,7 @@
               "nrqlQueries": [
                 {
                   "accountId": 0,
-                  "query": "FROM Metric SELECT rate((max(kentik.snmp.ifHCInOctets) + max(kentik.snmp.ifHCOutOctets))*8/1000/1000, 1 second) AS 'Mbps' FACET device_name, if_Alias OR if_Description AS 'interface_name' WHERE instrumentation.name = 'snmp' AND provider IN ('kentik-router','kentik-switch') LIMIT 100"
+                  "query": "FROM Metric SELECT rate((max(kentik.snmp.ifHCInOctets) + max(kentik.snmp.ifHCOutOctets))*8/1000/1000, 1 second) AS 'Mbps' FACET device_name, if_Name OR if_Alias OR if_Description AS 'interface_name' WHERE instrumentation.name = 'snmp' AND provider IN ('kentik-router','kentik-switch') LIMIT 100"
                 }
               ]
             },
@@ -119,7 +119,7 @@
               "nrqlQueries": [
                 {
                   "accountId": 0,
-                  "query": "FROM Metric SELECT rate(max(kentik.snmp.ifHCInOctets)*8/1000/1000, 1 second) AS 'Mbps' FACET device_name, if_Alias OR if_Description AS 'interface_name' TIMESERIES 5 MINUTES WHERE instrumentation.name = 'snmp' AND provider IN ('kentik-router','kentik-switch') LIMIT 100"
+                  "query": "FROM Metric SELECT rate(max(kentik.snmp.ifHCInOctets)*8/1000/1000, 1 second) AS 'Mbps' FACET device_name, if_Name OR if_Alias OR if_Description AS 'interface_name' TIMESERIES 5 MINUTES WHERE instrumentation.name = 'snmp' AND provider IN ('kentik-router','kentik-switch') LIMIT 100"
                 }
               ],
               "yAxisLeft": {
@@ -149,7 +149,7 @@
               "nrqlQueries": [
                 {
                   "accountId": 0,
-                  "query": "FROM Metric SELECT rate(max(kentik.snmp.ifHCInOctets)*8/1000/1000, 1 second) AS 'Mbps' FACET device_name, if_Alias OR if_Description AS 'interface_name' TIMESERIES 5 MINUTES WHERE instrumentation.name = 'snmp' AND provider IN ('kentik-router','kentik-switch') LIMIT 100"
+                  "query": "FROM Metric SELECT rate(max(kentik.snmp.ifHCInOctets)*8/1000/1000, 1 second) AS 'Mbps' FACET device_name, if_Name OR if_Alias OR if_Description AS 'interface_name' TIMESERIES 5 MINUTES WHERE instrumentation.name = 'snmp' AND provider IN ('kentik-router','kentik-switch') LIMIT 100"
                 }
               ]
             },
@@ -176,7 +176,7 @@
               "nrqlQueries": [
                 {
                   "accountId": 0,
-                  "query": "FROM Metric SELECT rate(max(kentik.snmp.ifHCOutOctets)*8/1000/1000, 1 second) AS 'Mbps' FACET device_name, if_Alias OR if_Description AS 'interface_name' TIMESERIES 5 MINUTES WHERE instrumentation.name = 'snmp' AND provider IN ('kentik-router','kentik-switch') LIMIT 100"
+                  "query": "FROM Metric SELECT rate(max(kentik.snmp.ifHCOutOctets)*8/1000/1000, 1 second) AS 'Mbps' FACET device_name, if_Name OR if_Alias OR if_Description AS 'interface_name' TIMESERIES 5 MINUTES WHERE instrumentation.name = 'snmp' AND provider IN ('kentik-router','kentik-switch') LIMIT 100"
                 }
               ],
               "yAxisLeft": {
@@ -206,7 +206,7 @@
               "nrqlQueries": [
                 {
                   "accountId": 0,
-                  "query": "FROM Metric SELECT rate(max(kentik.snmp.ifHCOutOctets)*8/1000/1000, 1 second) AS 'Mbps' FACET device_name, if_Alias OR if_Description AS 'interface_name' TIMESERIES 5 MINUTES WHERE instrumentation.name = 'snmp' AND provider IN ('kentik-router','kentik-switch') LIMIT 100"
+                  "query": "FROM Metric SELECT rate(max(kentik.snmp.ifHCOutOctets)*8/1000/1000, 1 second) AS 'Mbps' FACET device_name, if_Name OR if_Alias OR if_Description AS 'interface_name' TIMESERIES 5 MINUTES WHERE instrumentation.name = 'snmp' AND provider IN ('kentik-router','kentik-switch') LIMIT 100"
                 }
               ]
             },


### PR DESCRIPTION
updating interface names on the `Network - Routers and Switches` dashboard